### PR TITLE
Add user auth package and rename PRDs

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -5,10 +5,15 @@ import (
 	"net/http"
 
 	"alchemorsel/internal/health"
+	"alchemorsel/internal/user"
 )
 
 func main() {
 	http.HandleFunc("/healthz", health.Handler)
+	store := user.NewMemoryStore()
+	svc := &user.Service{Store: store, Secret: []byte("secret")}
+	http.HandleFunc("/v1/users", user.RegisterHandler(svc))
+	http.HandleFunc("/v1/tokens", user.LoginHandler(svc))
 	server := &http.Server{Addr: ":8080"}
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("http server error: %v", err)

--- a/backend/internal/user/handler.go
+++ b/backend/internal/user/handler.go
@@ -1,0 +1,49 @@
+package user
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// RegisterHandler returns an HTTP handler for user registration.
+func RegisterHandler(s *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		var req struct {
+			Email    string `json:"email"`
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		user, err := s.Register(ctx, req.Email, req.Password)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(user)
+	}
+}
+
+// LoginHandler returns an HTTP handler for user authentication.
+func LoginHandler(s *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		var req struct {
+			Email    string `json:"email"`
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		token, err := s.Authenticate(ctx, req.Email, req.Password)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": token})
+	}
+}

--- a/backend/internal/user/handler_test.go
+++ b/backend/internal/user/handler_test.go
@@ -1,0 +1,31 @@
+package user
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandlers(t *testing.T) {
+	store := NewMemoryStore()
+	svc := &Service{Store: store, Secret: []byte("secret")}
+
+	reg := httptest.NewRecorder()
+	body, _ := json.Marshal(map[string]string{"email": "a@x.com", "password": "p"})
+	RegisterHandler(svc)(reg, httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)))
+	if reg.Code != http.StatusCreated {
+		t.Fatalf("reg code %d", reg.Code)
+	}
+
+	login := httptest.NewRecorder()
+	LoginHandler(svc)(login, httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body)))
+	if login.Code != http.StatusOK {
+		t.Fatalf("login code %d", login.Code)
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(login.Body).Decode(&resp); err != nil || resp["token"] == "" {
+		t.Fatalf("bad token resp: %v", err)
+	}
+}

--- a/backend/internal/user/model.go
+++ b/backend/internal/user/model.go
@@ -1,0 +1,11 @@
+package user
+
+import "time"
+
+// User represents a registered application user.
+type User struct {
+	ID           int64
+	Email        string
+	PasswordHash string
+	CreatedAt    time.Time
+}

--- a/backend/internal/user/service.go
+++ b/backend/internal/user/service.go
@@ -1,0 +1,89 @@
+package user
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Service provides user management operations.
+type Service struct {
+	Store  Store
+	Secret []byte
+}
+
+// Register creates a new user account.
+func (s *Service) Register(ctx context.Context, email, password string) (User, error) {
+	if _, err := s.Store.FindByEmail(ctx, email); err == nil {
+		return User{}, errors.New("email already exists")
+	} else if !errors.Is(err, ErrNotFound) {
+		return User{}, err
+	}
+
+	hash, err := hashPassword(password)
+	if err != nil {
+		return User{}, err
+	}
+	u := User{Email: email, PasswordHash: hash, CreatedAt: time.Now()}
+	return s.Store.Create(ctx, u)
+}
+
+// Authenticate verifies credentials and returns a signed token.
+func (s *Service) Authenticate(ctx context.Context, email, password string) (string, error) {
+	u, err := s.Store.FindByEmail(ctx, email)
+	if err != nil {
+		return "", err
+	}
+	if ok := verifyPassword(u.PasswordHash, password); !ok {
+		return "", errors.New("invalid credentials")
+	}
+	return createToken(u.ID, s.Secret)
+}
+
+func hashPassword(pw string) (string, error) {
+	salt := make([]byte, 8)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(append(salt, []byte(pw)...))
+	// TODO: replace SHA-256 with Argon2 when available
+	return hex.EncodeToString(salt) + ":" + hex.EncodeToString(h[:]), nil
+}
+
+func verifyPassword(stored, pw string) bool {
+	parts := strings.Split(stored, ":")
+	if len(parts) != 2 {
+		return false
+	}
+	salt, err := hex.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	hash, err := hex.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	other := sha256.Sum256(append(salt, []byte(pw)...))
+	return subtle.ConstantTimeCompare(hash, other[:]) == 1
+}
+
+func createToken(id int64, secret []byte) (string, error) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := fmt.Sprintf(`{"sub":%d,"exp":%d}`, id, time.Now().Add(time.Hour).Unix())
+	payloadEnc := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	signing := header + "." + payloadEnc
+	h := hmac.New(sha256.New, secret)
+	if _, err := h.Write([]byte(signing)); err != nil {
+		return "", err
+	}
+	sig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+	return signing + "." + sig, nil
+}

--- a/backend/internal/user/service_test.go
+++ b/backend/internal/user/service_test.go
@@ -1,0 +1,29 @@
+package user
+
+import (
+	"context"
+	"testing"
+)
+
+func TestService_RegisterAndAuthenticate(t *testing.T) {
+	store := NewMemoryStore()
+	svc := &Service{Store: store, Secret: []byte("secret")}
+	ctx := context.Background()
+
+	u, err := svc.Register(ctx, "a@example.com", "pass")
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	if u.ID == 0 {
+		t.Fatalf("expected ID set")
+	}
+
+	token, err := svc.Authenticate(ctx, "a@example.com", "pass")
+	if err != nil || token == "" {
+		t.Fatalf("authenticate failed: %v token:%q", err, token)
+	}
+
+	if _, err := svc.Authenticate(ctx, "a@example.com", "bad"); err == nil {
+		t.Fatal("expected bad password error")
+	}
+}

--- a/backend/internal/user/store.go
+++ b/backend/internal/user/store.go
@@ -1,0 +1,49 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrNotFound indicates no user was found for the query.
+var ErrNotFound = errors.New("user not found")
+
+// Store provides persistence for users.
+type Store interface {
+	Create(ctx context.Context, u User) (User, error)
+	FindByEmail(ctx context.Context, email string) (User, error)
+}
+
+// MemoryStore is an in-memory Store implementation.
+type MemoryStore struct {
+	mu    sync.Mutex
+	next  int64
+	users map[string]User
+}
+
+// NewMemoryStore creates a new MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{users: make(map[string]User)}
+}
+
+// Create stores a new user.
+func (m *MemoryStore) Create(ctx context.Context, u User) (User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.next++
+	u.ID = m.next
+	m.users[u.Email] = u
+	return u, nil
+}
+
+// FindByEmail retrieves a user by email.
+func (m *MemoryStore) FindByEmail(ctx context.Context, email string) (User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	u, ok := m.users[email]
+	if !ok {
+		return User{}, ErrNotFound
+	}
+	return u, nil
+}

--- a/docs/prd/recipe-create.md
+++ b/docs/prd/recipe-create.md
@@ -1,0 +1,56 @@
+# Recipe Creation and Editing
+
+## Summary
+
+Enable users to create new recipes manually or generate them using the integrated LLM. Users can edit recipes they own at any time.
+
+## User Story
+
+As a cook, I want to create or generate recipes and edit them later so I can share my unique dishes with the community.
+
+## Requirements
+
+- REST endpoints to create, read, update, and delete recipes owned by the user.
+- Optional flag to request AI generation of a recipe based on a prompt.
+- Validation for required fields such as title, ingredients, and steps.
+- Only the recipe owner can update or delete a recipe.
+- Clear errors for invalid input or unauthorized actions.
+
+## Data Model
+
+```
+Recipe {
+  ID int64
+  Title string
+  Description string
+  Ingredients []string
+  Steps []string
+  Tags []string
+  CreatedBy int64
+  CreatedAt time.Time
+  UpdatedAt time.Time
+}
+```
+
+## API Endpoints
+
+| Method | Path               | Description                        |
+| ------ | ------------------ | ---------------------------------- |
+| POST   | `/v1/recipes`      | Create a new recipe (manual or AI) |
+| PUT    | `/v1/recipes/:id`  | Update an existing recipe          |
+| DELETE | `/v1/recipes/:id`  | Delete an existing recipe          |
+
+Request body for AI generation includes a `prompt` field describing the desired recipe.
+
+## Edge Cases
+
+- Missing required fields when creating a recipe.
+- Attempt to edit or delete a recipe not owned by the user.
+- LLM generation fails or returns invalid output.
+
+## Acceptance Criteria
+
+- Recipes can be created manually with valid data.
+- AI generation returns a new recipe when a prompt is provided.
+- Only the owner can modify or delete their recipes.
+- Unit tests cover manual creation, AI generation, update, and failure scenarios.

--- a/docs/prd/recipe-mod.md
+++ b/docs/prd/recipe-mod.md
@@ -1,0 +1,49 @@
+# Recipe Modification Requests
+
+## Summary
+
+Allow users to submit modification requests for existing recipes. Requests are processed by the LLM to adjust ingredients, steps, or servings based on user preferences.
+
+## User Story
+
+As a user, I want to tweak existing recipes to suit my dietary needs or portion sizes so that I can cook meals tailored to me.
+
+## Requirements
+
+- REST endpoint to submit a modification request referencing an existing recipe ID and desired changes.
+- LLM processes the request and returns an updated recipe version.
+- Original recipe must remain unchanged; modifications are stored as new recipes linked to the source.
+- Validation for reasonable serving sizes and ingredient substitutions.
+- Clear error handling if the LLM fails to generate a valid modification.
+
+## Data Model
+
+```
+RecipeModification {
+  ID int64
+  SourceRecipeID int64
+  ModifiedRecipeID int64
+  RequestedBy int64
+  Prompt string
+  CreatedAt time.Time
+}
+```
+
+## API Endpoints
+
+| Method | Path                       | Description                           |
+| ------ | -------------------------- | ------------------------------------- |
+| POST   | `/v1/recipes/:id/modify`   | Request a modified version of a recipe |
+
+## Edge Cases
+
+- Invalid recipe ID supplied.
+- LLM unable to create a coherent modification.
+- User submits conflicting or impossible requests.
+
+## Acceptance Criteria
+
+- Providing a valid prompt produces a new recipe based on the original.
+- Original recipe is preserved and modification references it.
+- Errors are returned for invalid requests or generation failures.
+- Unit tests cover successful modifications, invalid IDs, and LLM failure cases.

--- a/docs/prd/recipe-search.md
+++ b/docs/prd/recipe-search.md
@@ -1,0 +1,59 @@
+# Recipe Search and Browse
+
+## Summary
+
+Provide users with robust search and browsing functionality so they can easily find recipes by keyword, ingredient, or tag. Supports pagination and sorting for large result sets.
+
+## User Story
+
+As a user, I want to search for recipes matching certain terms or ingredients so that I can quickly discover meals to cook.
+
+## Requirements
+
+- REST endpoint to search recipes with query parameters for text, ingredients, and tags.
+- Results must be paginated and sortable by relevance or popularity.
+- Errors for invalid queries or missing parameters must be descriptive.
+- Search is available to both authenticated and anonymous users.
+
+## Data Model
+
+```
+Recipe {
+  ID int64
+  Title string
+  Description string
+  Ingredients []string
+  Steps []string
+  Tags []string
+  CreatedBy int64
+  CreatedAt time.Time
+  UpdatedAt time.Time
+}
+```
+
+## API Endpoints
+
+| Method | Path            | Description                  |
+| ------ | --------------- | ---------------------------- |
+| GET    | `/v1/recipes`   | Search and list recipes      |
+| GET    | `/v1/recipes/:id` | Retrieve recipe details |
+
+Query parameters for `/v1/recipes`:
+- `q` search text
+- `ingredient` filter by ingredient (repeatable)
+- `tag` filter by tag (repeatable)
+- `page` page number
+- `limit` results per page
+
+## Edge Cases
+
+- No recipes match the query.
+- Invalid page or limit values.
+- Very long search terms.
+
+## Acceptance Criteria
+
+- Searching with no filters returns the first page of recipes.
+- Filters by ingredient and tag narrow results correctly.
+- Pagination works and returns total count.
+- Unit tests cover no results, valid searches, and invalid parameter cases.

--- a/docs/prd/user-profile.md
+++ b/docs/prd/user-profile.md
@@ -1,0 +1,52 @@
+# User Profiles
+
+## Summary
+
+Allow each user to view and update personal details such as display name, avatar, and dietary preferences. Profiles personalize recipe results and are required for other features like favorites and pantry management.
+
+## User Story
+
+As an authenticated user, I want to manage my profile so that Alchemorsel can tailor recipes and settings to my needs.
+
+## Requirements
+
+- REST endpoints to retrieve and update the current user's profile.
+- Only authenticated users can modify their own profile.
+- Profile includes display name, avatar URL, bio, and dietary preference fields.
+- Validation for field lengths and required information.
+- Descriptive error messages for invalid input or unauthorized access.
+
+## Data Model
+
+```
+Profile {
+  ID int64
+  UserID int64
+  DisplayName string
+  AvatarURL string
+  Bio string
+  DietaryPreferences []string
+  CreatedAt time.Time
+  UpdatedAt time.Time
+}
+```
+
+## API Endpoints
+
+| Method | Path            | Description                |
+| ------ | --------------- | -------------------------- |
+| GET    | `/v1/profile`   | Get the authenticated user's profile |
+| PUT    | `/v1/profile`   | Update the authenticated user's profile |
+
+## Edge Cases
+
+- Attempt to update another user's profile.
+- Missing or invalid avatar URL.
+- Display name exceeding length limits.
+
+## Acceptance Criteria
+
+- `GET /v1/profile` returns 200 with profile data for authenticated user.
+- `PUT /v1/profile` returns 200 and updates the profile when data is valid.
+- Validation errors return 400 with actionable messages.
+- Unit tests cover success, validation errors, and unauthorized cases.

--- a/docs/tasks/recipe-create.tasks.md
+++ b/docs/tasks/recipe-create.tasks.md
@@ -1,0 +1,5 @@
+- Define Recipe model and migration
+- Implement POST /v1/recipes for manual creation
+- Implement optional AI generation path
+- Implement PUT/DELETE handlers for recipe owner only
+- Write unit tests for handlers and services

--- a/docs/tasks/recipe-mod.tasks.md
+++ b/docs/tasks/recipe-mod.tasks.md
@@ -1,0 +1,5 @@
+- Endpoint POST /v1/recipes/:id/modify
+- Call LLM to create modified recipe
+- Save modification as new recipe linked to original
+- Handle validation errors and LLM failures
+- Add tests covering success and failure

--- a/docs/tasks/recipe-search.tasks.md
+++ b/docs/tasks/recipe-search.tasks.md
@@ -1,0 +1,4 @@
+- Implement GET /v1/recipes with query params q, ingredient, tag
+- Add pagination parameters page and limit
+- Implement service method to filter results
+- Add unit tests for search filtering and pagination

--- a/docs/tasks/user-auth.tasks.md
+++ b/docs/tasks/user-auth.tasks.md
@@ -1,0 +1,5 @@
+- Create User model and memory store
+- Implement registration and login services
+- Add JWT token generation with shared secret
+- Write HTTP handlers for /v1/users and /v1/tokens
+- Add unit tests for service and handlers

--- a/docs/tasks/user-profile.tasks.md
+++ b/docs/tasks/user-profile.tasks.md
@@ -1,0 +1,5 @@
+- Define Profile model linked to User
+- Implement GET and PUT /v1/profile
+- Validate display name and avatar URL
+- Update recipe personalization logic using profile
+- Unit tests for profile retrieval and update


### PR DESCRIPTION
## Summary
- implement initial user auth service with in-memory store
- expose /v1/users and /v1/tokens handlers
- rename recipe/user PRDs to blueprint names
- document task lists for all PRDs

## Testing
- `go test ./...`
- `golangci-lint run ./...`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841fa4819d8832fb3a0472b6038242a