### PR TITLE
Add Argon2 password hashing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,6 +3,7 @@
 This directory contains the Go backend for **Alchemorsel**.
 
 ## Requirements
+
 - Go 1.20+
 
 ## Running
@@ -12,3 +13,21 @@ go run ./cmd/api
 ```
 
 The default server exposes a `/healthz` endpoint on port `8080`.
+
+## Authentication Endpoints
+
+Passwords are hashed using **Argon2** before being stored.
+
+### Register
+
+```bash
+curl -X POST -d '{"email":"user@example.com","password":"password"}' \
+  http://localhost:8080/v1/users
+```
+
+### Login
+
+```bash
+curl -X POST -d '{"email":"user@example.com","password":"password"}' \
+  http://localhost:8080/v1/tokens
+```

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -3,14 +3,30 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 
+	"alchemorsel/internal/auth"
 	"alchemorsel/internal/health"
+	"alchemorsel/internal/users"
 )
 
 func main() {
+	store := users.NewMemoryStore()
+	svc := &auth.Service{Store: store, Secret: envOr("JWT_SECRET", "secret")}
+
 	http.HandleFunc("/healthz", health.Handler)
+	http.HandleFunc("/v1/users", auth.RegisterHandler(svc))
+	http.HandleFunc("/v1/tokens", auth.LoginHandler(svc))
+
 	server := &http.Server{Addr: ":8080"}
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("http server error: %v", err)
 	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,7 @@
 module alchemorsel
 
 go 1.23.8
+
+require golang.org/x/crypto v0.39.0
+
+require golang.org/x/sys v0.33.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
+golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/backend/internal/auth/auth.go
+++ b/backend/internal/auth/auth.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"alchemorsel/internal/users"
+)
+
+// Service handles user registration and login.
+type Service struct {
+	Store  users.Store
+	Secret string
+}
+
+// RegisterRequest holds input for registration.
+type RegisterRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// LoginRequest holds input for login.
+type LoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// Register registers a new user and returns a JWT.
+func (s *Service) Register(ctx context.Context, req RegisterRequest) (string, error) {
+	if len(req.Password) < 8 {
+		return "", errors.New("password must be at least 8 characters")
+	}
+	hashed, err := hashPassword([]byte(req.Password))
+	if err != nil {
+		return "", err
+	}
+	u := &users.User{Email: req.Email, PasswordHash: hashed}
+	if err := s.Store.Create(ctx, u); err != nil {
+		return "", err
+	}
+	return generateJWT(u.ID, s.Secret), nil
+}
+
+// Login authenticates a user and returns a JWT.
+func (s *Service) Login(ctx context.Context, req LoginRequest) (string, error) {
+	u, err := s.Store.FindByEmail(ctx, req.Email)
+	if err != nil {
+		return "", err
+	}
+	if !verifyPassword([]byte(req.Password), u.PasswordHash) {
+		return "", errors.New("invalid credentials")
+	}
+	return generateJWT(u.ID, s.Secret), nil
+}
+
+func generateJWT(userID int64, secret string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payloadBytes, _ := json.Marshal(map[string]any{
+		"sub": userID,
+		"exp": time.Now().Add(24 * time.Hour).Unix(),
+	})
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	signing := header + "." + payload
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(signing))
+	sig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+	return signing + "." + sig
+}
+
+// RegisterHandler handles POST /v1/users
+func RegisterHandler(s *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req RegisterRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		token, err := s.Register(r.Context(), req)
+		if err != nil {
+			status := http.StatusBadRequest
+			if errors.Is(err, users.ErrEmailExists) {
+				status = http.StatusConflict
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		if _, err := w.Write([]byte(token)); err != nil {
+			http.Error(w, "write error", http.StatusInternalServerError)
+		}
+	}
+}
+
+// LoginHandler handles POST /v1/tokens
+func LoginHandler(s *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req LoginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		token, err := s.Login(r.Context(), req)
+		if err != nil {
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+			return
+		}
+		if _, err := w.Write([]byte(token)); err != nil {
+			http.Error(w, "write error", http.StatusInternalServerError)
+		}
+	}
+}

--- a/backend/internal/auth/auth_test.go
+++ b/backend/internal/auth/auth_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"alchemorsel/internal/users"
+)
+
+func setup() *Service {
+	return &Service{Store: users.NewMemoryStore(), Secret: "test"}
+}
+
+func TestRegisterHandler(t *testing.T) {
+	svc := setup()
+	cases := []struct {
+		name       string
+		req        RegisterRequest
+		wantStatus int
+	}{
+		{"ok", RegisterRequest{Email: "a@b.com", Password: "password"}, http.StatusCreated},
+		{"weak", RegisterRequest{Email: "x@y.com", Password: "short"}, http.StatusBadRequest},
+		{"dup", RegisterRequest{Email: "a@b.com", Password: "password"}, http.StatusConflict},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(tc.req)
+			r := httptest.NewRequest(http.MethodPost, "/v1/users", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			RegisterHandler(svc)(w, r)
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d", tc.wantStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestLoginHandler(t *testing.T) {
+	svc := setup()
+	// register a user first
+	_, err := svc.Register(context.Background(), RegisterRequest{Email: "login@t.com", Password: "password"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name       string
+		req        LoginRequest
+		wantStatus int
+	}{
+		{"ok", LoginRequest{Email: "login@t.com", Password: "password"}, http.StatusOK},
+		{"badpass", LoginRequest{Email: "login@t.com", Password: "wrong"}, http.StatusUnauthorized},
+		{"nouser", LoginRequest{Email: "missing@t.com", Password: "pass"}, http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(tc.req)
+			r := httptest.NewRequest(http.MethodPost, "/v1/tokens", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			LoginHandler(svc)(w, r)
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected %d, got %d", tc.wantStatus, w.Code)
+			}
+		})
+	}
+}

--- a/backend/internal/auth/hash.go
+++ b/backend/internal/auth/hash.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	argonTime    uint32 = 1
+	argonMemory  uint32 = 64 * 1024
+	argonThreads uint8  = 4
+	argonKeyLen  uint32 = 32
+	saltLen             = 16
+)
+
+// hashPassword hashes the password using Argon2ID and returns an encoded string.
+// The returned format is base64(salt):base64(hash).
+func hashPassword(password []byte) (string, error) {
+	salt := make([]byte, saltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+	hash := argon2.IDKey(password, salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	return base64.RawStdEncoding.EncodeToString(salt) + ":" + base64.RawStdEncoding.EncodeToString(hash), nil
+}
+
+// verifyPassword compares the password with the encoded Argon2ID hash.
+func verifyPassword(password []byte, encoded string) bool {
+	parts := strings.Split(encoded, ":")
+	if len(parts) != 2 {
+		return false
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	hash, err := base64.RawStdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	other := argon2.IDKey(password, salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	return subtle.ConstantTimeCompare(hash, other) == 1
+}

--- a/backend/internal/users/user.go
+++ b/backend/internal/users/user.go
@@ -1,0 +1,64 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// User represents a registered account.
+type User struct {
+	ID           int64
+	Email        string
+	PasswordHash string
+	CreatedAt    time.Time
+}
+
+// Store defines persistence behavior for Users.
+type Store interface {
+	Create(ctx context.Context, u *User) error
+	FindByEmail(ctx context.Context, email string) (*User, error)
+}
+
+var ErrEmailExists = errors.New("email already in use")
+var ErrNotFound = errors.New("user not found")
+
+// MemoryStore is an in-memory implementation of Store.
+type MemoryStore struct {
+	mu     sync.RWMutex
+	users  map[string]*User
+	nextID int64
+}
+
+// NewMemoryStore creates an empty MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{users: make(map[string]*User)}
+}
+
+// Create stores a new user if the email is unused.
+func (m *MemoryStore) Create(ctx context.Context, u *User) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.users[u.Email]; ok {
+		return ErrEmailExists
+	}
+	m.nextID++
+	u.ID = m.nextID
+	u.CreatedAt = time.Now()
+	clone := *u
+	m.users[u.Email] = &clone
+	return nil
+}
+
+// FindByEmail returns a user by email.
+func (m *MemoryStore) FindByEmail(ctx context.Context, email string) (*User, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	u, ok := m.users[email]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	clone := *u
+	return &clone, nil
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  title: Alchemorsel API
+  version: 1.0.0
+paths:
+  /v1/users:
+    post:
+      summary: Register a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        "201":
+          description: created
+          content:
+            text/plain:
+              schema:
+                type: string
+  /v1/tokens:
+    post:
+      summary: Login and obtain JWT
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        "200":
+          description: token returned
+          content:
+            text/plain:
+              schema:
+                type: string


### PR DESCRIPTION
## Summary
- implement Argon2 password hashing for auth service
- update registration and login to use Argon2
- document Argon2 usage

## Testing
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841fb30d498832f86b85347f36b038a