### PR TITLE
Add recipe creation endpoint

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -7,16 +7,20 @@ import (
 
 	"alchemorsel/internal/auth"
 	"alchemorsel/internal/health"
+	"alchemorsel/internal/recipes"
 	"alchemorsel/internal/users"
 )
 
 func main() {
 	store := users.NewMemoryStore()
 	svc := &auth.Service{Store: store, Secret: envOr("JWT_SECRET", "secret")}
+	recipeStore := recipes.NewMemoryStore()
+	recipeSvc := &recipes.Service{Store: recipeStore}
 
 	http.HandleFunc("/healthz", health.Handler)
 	http.HandleFunc("/v1/users", auth.RegisterHandler(svc))
 	http.HandleFunc("/v1/tokens", auth.LoginHandler(svc))
+	http.HandleFunc("/v1/recipes", recipes.CreateHandler(recipeSvc))
 
 	server := &http.Server{Addr: ":8080"}
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/backend/internal/recipes/handler.go
+++ b/backend/internal/recipes/handler.go
@@ -1,0 +1,29 @@
+package recipes
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// CreateHandler returns an HTTP handler for POST /v1/recipes.
+func CreateHandler(s *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req CreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		recipe, err := s.Create(r.Context(), 1, req)
+		if err != nil {
+			if errors.Is(err, ErrInvalidInput) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			} else {
+				http.Error(w, "server error", http.StatusInternalServerError)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(recipe)
+	}
+}

--- a/backend/internal/recipes/handler_test.go
+++ b/backend/internal/recipes/handler_test.go
@@ -1,0 +1,35 @@
+package recipes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateHandler(t *testing.T) {
+	svc := &Service{Store: NewMemoryStore()}
+	body, _ := json.Marshal(CreateRequest{Title: "T", Ingredients: []string{"i"}, Steps: []string{"s"}})
+	r := httptest.NewRequest(http.MethodPost, "/v1/recipes", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	CreateHandler(svc)(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("code %d", w.Code)
+	}
+	var resp Recipe
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil || resp.ID == 0 {
+		t.Fatalf("bad response: %v", err)
+	}
+}
+
+func TestCreateHandler_BadInput(t *testing.T) {
+	svc := &Service{Store: NewMemoryStore()}
+	body, _ := json.Marshal(CreateRequest{})
+	r := httptest.NewRequest(http.MethodPost, "/v1/recipes", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	CreateHandler(svc)(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code %d", w.Code)
+	}
+}

--- a/backend/internal/recipes/service.go
+++ b/backend/internal/recipes/service.go
@@ -1,0 +1,42 @@
+package recipes
+
+import (
+	"context"
+	"errors"
+)
+
+// Service provides recipe creation operations.
+type Service struct {
+	Store Store
+}
+
+// CreateRequest defines input for creating a recipe.
+type CreateRequest struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Ingredients []string `json:"ingredients"`
+	Steps       []string `json:"steps"`
+	Tags        []string `json:"tags"`
+}
+
+// ErrInvalidInput is returned when the request is missing required fields.
+var ErrInvalidInput = errors.New("invalid recipe input")
+
+// Create stores a new recipe owned by the given user.
+func (s *Service) Create(ctx context.Context, userID int64, req CreateRequest) (*Recipe, error) {
+	if req.Title == "" || len(req.Ingredients) == 0 || len(req.Steps) == 0 {
+		return nil, ErrInvalidInput
+	}
+	r := &Recipe{
+		Title:       req.Title,
+		Description: req.Description,
+		Ingredients: append([]string(nil), req.Ingredients...),
+		Steps:       append([]string(nil), req.Steps...),
+		Tags:        append([]string(nil), req.Tags...),
+		CreatedBy:   userID,
+	}
+	if err := s.Store.Create(ctx, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}

--- a/backend/internal/recipes/service_test.go
+++ b/backend/internal/recipes/service_test.go
@@ -1,0 +1,30 @@
+package recipes
+
+import (
+	"context"
+	"testing"
+)
+
+func TestService_Create(t *testing.T) {
+	svc := &Service{Store: NewMemoryStore()}
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		req     CreateRequest
+		wantErr bool
+	}{
+		{"ok", CreateRequest{Title: "T", Ingredients: []string{"i"}, Steps: []string{"s"}}, false},
+		{"missing", CreateRequest{Ingredients: []string{"i"}, Steps: []string{"s"}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.Create(ctx, 1, tc.req)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected: %v", err)
+			}
+		})
+	}
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -45,3 +45,36 @@ paths:
             text/plain:
               schema:
                 type: string
+  /v1/recipes:
+    post:
+      summary: Create a new recipe
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                ingredients:
+                  type: array
+                  items:
+                    type: string
+                steps:
+                  type: array
+                  items:
+                    type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object

--- a/docs/task-list.md
+++ b/docs/task-list.md
@@ -7,3 +7,4 @@
 - [x] Implement Argon2 password hashing
 - [x] User authentication PRD complete
 - [x] Recipe model, in-memory store, and migration
+- [x] POST /v1/recipes endpoint


### PR DESCRIPTION
## Summary
- create recipes service and HTTP handler for POST /v1/recipes
- wire recipe handler into API main program
- document new endpoint in OpenAPI spec
- update task list

## Testing
- `go test ./...`
- `golangci-lint run ./...`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68420be48e8c832f9c304194c14ef52e