### PR TITLE
Implement recipe modification endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,3 +31,19 @@ curl -X POST -d '{"email":"user@example.com","password":"password"}' \
 curl -X POST -d '{"email":"user@example.com","password":"password"}' \
   http://localhost:8080/v1/tokens
 ```
+
+## Recipe Endpoints
+
+### Create Recipe
+
+```bash
+curl -X POST -d '{"title":"Soup","ingredients":["water"],"steps":["boil"]}' \
+  http://localhost:8080/v1/recipes
+```
+
+### Modify Recipe
+
+```bash
+curl -X POST -d '{"prompt":"spicy"}' \
+  http://localhost:8080/v1/recipes/1/modify
+```

--- a/backend/internal/recipes/handler.go
+++ b/backend/internal/recipes/handler.go
@@ -4,9 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-
 	"strconv"
-
+	"strings"
 )
 
 // CreateHandler returns an HTTP handler for POST /v1/recipes.
@@ -31,7 +30,6 @@ func CreateHandler(s *Service) http.HandlerFunc {
 	}
 }
 
-
 // SearchHandler returns an HTTP handler for GET /v1/recipes.
 func SearchHandler(s *Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -54,3 +52,39 @@ func SearchHandler(s *Service) http.HandlerFunc {
 	}
 }
 
+// ModifyHandler returns an HTTP handler for POST /v1/recipes/:id/modify.
+func ModifyHandler(s *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if len(parts) < 3 {
+			http.NotFound(w, r)
+			return
+		}
+		id, err := strconv.ParseInt(parts[2], 10, 64)
+		if err != nil {
+			http.Error(w, "invalid id", http.StatusBadRequest)
+			return
+		}
+		var req struct {
+			Prompt string `json:"prompt"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		recipe, err := s.Modify(r.Context(), 1, id, req.Prompt)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrNotFound):
+				http.NotFound(w, r)
+			case errors.Is(err, ErrInvalidPrompt) || errors.Is(err, ErrGenerationFailed):
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			default:
+				http.Error(w, "server error", http.StatusInternalServerError)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(recipe)
+	}
+}

--- a/backend/internal/recipes/llm.go
+++ b/backend/internal/recipes/llm.go
@@ -1,0 +1,29 @@
+package recipes
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// LLM defines recipe modification generation behavior.
+type LLM interface {
+	ModifyRecipe(ctx context.Context, original *Recipe, prompt string) (*Recipe, error)
+}
+
+// ErrGenerationFailed is returned when the LLM cannot produce a result.
+var ErrGenerationFailed = errors.New("llm generation failed")
+
+// FakeLLM is a simple in-process implementation used for tests.
+type FakeLLM struct{}
+
+// ModifyRecipe returns a modified copy of the recipe unless the prompt contains "fail".
+func (FakeLLM) ModifyRecipe(ctx context.Context, original *Recipe, prompt string) (*Recipe, error) {
+	if strings.Contains(prompt, "fail") {
+		return nil, ErrGenerationFailed
+	}
+	r := *original
+	r.ID = 0
+	r.Title = original.Title + " - " + prompt
+	return &r, nil
+}

--- a/backend/internal/recipes/modification.go
+++ b/backend/internal/recipes/modification.go
@@ -1,0 +1,46 @@
+package recipes
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Modification links a generated recipe back to its source.
+type Modification struct {
+	ID               int64
+	SourceRecipeID   int64
+	ModifiedRecipeID int64
+	RequestedBy      int64
+	Prompt           string
+	CreatedAt        time.Time
+}
+
+// ModStore defines persistence for recipe modifications.
+type ModStore interface {
+	Create(ctx context.Context, m *Modification) error
+}
+
+// MemoryModStore is an in-memory ModStore implementation.
+type MemoryModStore struct {
+	mu     sync.Mutex
+	nextID int64
+	data   map[int64]*Modification
+}
+
+// NewMemoryModStore returns an empty MemoryModStore.
+func NewMemoryModStore() *MemoryModStore {
+	return &MemoryModStore{data: make(map[int64]*Modification)}
+}
+
+// Create saves a modification entry.
+func (m *MemoryModStore) Create(ctx context.Context, mod *Modification) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	mod.ID = m.nextID
+	mod.CreatedAt = time.Now()
+	clone := *mod
+	m.data[mod.ID] = &clone
+	return nil
+}

--- a/backend/internal/recipes/service_test.go
+++ b/backend/internal/recipes/service_test.go
@@ -2,9 +2,8 @@ package recipes
 
 import (
 	"context"
-
+	"errors"
 	"strings"
-
 	"testing"
 )
 
@@ -44,5 +43,39 @@ func TestService_Search(t *testing.T) {
 	results, err := svc.Search(ctx, SearchRequest{Q: "banana", Page: 1, Limit: 10})
 	if err != nil || len(results) != 1 || !strings.Contains(results[0].Title, "Banana") {
 		t.Fatalf("unexpected search result: %v %v", err, results)
+	}
+}
+
+func TestService_Modify(t *testing.T) {
+	store := NewMemoryStore()
+	modStore := NewMemoryModStore()
+	svc := &Service{Store: store, ModStore: modStore, LLM: FakeLLM{}}
+	ctx := context.Background()
+	r, err := svc.Create(ctx, 1, CreateRequest{Title: "Soup", Ingredients: []string{"carrot"}, Steps: []string{"mix"}})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	newR, err := svc.Modify(ctx, 1, r.ID, "spicy")
+	if err != nil {
+		t.Fatalf("modify: %v", err)
+	}
+	if newR.ID == r.ID || !strings.Contains(newR.Title, "spicy") {
+		t.Fatalf("unexpected modified recipe: %+v", newR)
+	}
+	if len(modStore.data) != 1 {
+		t.Fatalf("mod not stored")
+	}
+}
+
+func TestService_Modify_Err(t *testing.T) {
+	store := NewMemoryStore()
+	svc := &Service{Store: store, ModStore: NewMemoryModStore(), LLM: FakeLLM{}}
+	ctx := context.Background()
+	if _, err := svc.Modify(ctx, 1, 99, "ok"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected not found, got %v", err)
+	}
+	r, _ := svc.Create(ctx, 1, CreateRequest{Title: "Toast", Ingredients: []string{"bread"}, Steps: []string{"toast"}})
+	if _, err := svc.Modify(ctx, 1, r.ID, "fail"); !errors.Is(err, ErrGenerationFailed) {
+		t.Fatalf("expected generation failure")
 	}
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -116,3 +116,29 @@ paths:
             application/json:
               schema:
                 type: object
+
+  /v1/recipes/{id}/modify:
+    post:
+      summary: Request a modified recipe
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                prompt:
+                  type: string
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object

--- a/docs/task-list.md
+++ b/docs/task-list.md
@@ -11,3 +11,6 @@
 
 - [x] GET /v1/recipes search endpoint
 
+- [x] POST /v1/recipes/:id/modify endpoint
+
+All recipe modification tasks are now complete.

--- a/docs/tasks/recipe-mod.tasks.md
+++ b/docs/tasks/recipe-mod.tasks.md
@@ -1,5 +1,7 @@
-- Endpoint POST /v1/recipes/:id/modify
-- Call LLM to create modified recipe
-- Save modification as new recipe linked to original
-- Handle validation errors and LLM failures
-- Add tests covering success and failure
+- [x] Endpoint POST /v1/recipes/:id/modify
+- [x] Call LLM to create modified recipe
+- [x] Save modification as new recipe linked to original
+- [x] Handle validation errors and LLM failures
+- [x] Add tests covering success and failure
+
+All tasks for the recipe modification endpoint have been completed.


### PR DESCRIPTION
## Summary
- allow generating modifications of recipes via a fake LLM
- record recipe modifications in memory
- expose POST `/v1/recipes/{id}/modify`
- document new endpoint and usage
- mark recipe modification tasks complete

## Testing
- `go test ./...`
- `golangci-lint run ./...`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68421039eb28832f88e00455bede84f5